### PR TITLE
Feedback

### DIFF
--- a/feedback/s3-bb-def.R
+++ b/feedback/s3-bb-def.R
@@ -1,0 +1,66 @@
+# constructor:
+new_bb <- function(text) {
+  checkmate::assert_character(text)
+  # replace ((consonants) (1-2 vowels) (consonants)) with
+  # ((consonants) (vowels) b (same vowels again) (consonants)):
+  match <- "([^aeiouäöüAEIOUÄÜÖ]*)([aeiouäöü]{1,2})([^aeiouäöü]*)"
+  structure(
+    gsub(pattern = match, replacement = "\\1\\2b\\2\\3", x = text),
+    class = c("bb", class(text))
+  )
+}
+# validator:
+validate_bb <- function(object) {
+  checkmate::assert_class(object, "bb")
+  # recursive validation for lists:
+  if (is.list(object)) {
+    rapply(object, validate_bb)
+    return(object)
+  }
+  # check levels for factors, for all others get rid of dimension attributes
+  data <- if (inherits(object, "factor")) {
+    levels(object)
+  } else {
+    as.vector(object)
+  }
+  checkmate::assert_character(data)
+  # chebeck vabalibid beebee-labanguabuagebe (very superficially):
+  # regexp: some consonants - some vowels - "b" - same vowels as before the "b"
+  match <- "([^aeiouäöüAEIOUÄÜÖ ]*)([aeiouäöü]{1,2})b\\2"
+  looks_like_bb <- grepl(pattern = match, x = object)
+  if (!all(looks_like_bb)) {
+    stop(new_bb("these entries don't look like bb-language: \n"),
+         object[!looks_like_bb])
+  }
+  object
+}
+
+#-------------------------------------------------------------------------------
+
+# Turn character inputs <x> into bb-fied objects -- i.e, objects with an
+# additional class entry "bb" in addition to its original class and all
+# strings in the object turned into beebee-labanguabuagebe.
+bb <- function(x, ...) UseMethod("bb")
+# the constructor is defined as a generic, and we define methods for the generic
+# in order to convert different data types to class "bb":
+
+# default works for character vectors/matrices/arrays, else throws error
+bb.default <- function(x) {
+  if (mode(x) != "character") {
+    stop(new_bb("non-character objects cannot be turned into bb-objects.\n"))
+  }
+  validate_bb(new_bb(x))
+}
+
+# also works for ordered (subclass of factor)
+bb.factor <- function(x) {
+  levels(x) <- unclass(bb.default(levels(x)))
+  class(x) <- c("bb", class(x))
+  x
+}
+
+bb.list <- function(x) {
+  result <- lapply(x, bb)
+  class(result) <- c("bb", class(result))
+  result
+}

--- a/feedback/s3-bb-ex.Rmd
+++ b/feedback/s3-bb-ex.Rmd
@@ -1,0 +1,21 @@
+## `S3` -- *Bebe-Sprabachebe*
+
+**Be-Sprache** bedeutet nach jedem Vokal oder Diphtong^["au", "ei", "oi", "eu", etc.] die Konsonanten davor mit "b" zu ersetzen und bis zu diesem Vokal oder Diphtong zu wiederholen: 
+*Bebe-Sprabachebe bebedeubeutebet nabach jebedebem Vobokabal obodeber Dibiphtobong diebie Kobonsobonabanteben dabavobor mibit "b" zubu ebersebetzeben ubund bibis zubu diebiesebem Vobokabal obodeber Dibiphtobong zubu wiebiedeberhoboleben*.
+```{r, bb_starter, code = readLines("s3-bb-starter.R")}
+```
+
+```{r, bb_sol, code = readLines("s3-bb-def.R"), echo=FALSE}
+```
+Benutzen Sie den oben angegebenen Code als Ausgangsbasis um daraus eine standardkonforme Konstruktorfunktion zu machen sowie Interface-Methoden für eine neu zu definierende `bb()`-*generic* zu schreiben die `character`-Vektoren, -Matrizen, -Arrays, -Listen und `factor`-Variablen entsprechend verunstalten und den verunstalteten Ergebnissen die (zusätzliche) Klasse `bb` zuweisen.  
+Beachten Sie die Hinweise zu Interface- und Konstruktorfunktionen etc im entsprechenden [Kapitel aus *Advanced R*](https://adv-r.hadley.nz/s3.html#classes).  
+Überlegen Sie sich gut für welche Klassen eigene Methoden wirklich nötig sind und 
+nutzen Sie Vererbungsrelationen/Klassenhierarchien und geschickten *method dispatch* aus um mit möglichst wenig verschiedenen 
+Methoden auszukommen.^[Spoiler: 3 bis max. 4 Methoden reichen aus um alle Testfälle unten komplett abzudecken....]
+
+Überprüfen Sie ihre Implementation mit folgenden Testfällen:
+```{r, bb_example, code = readLines("test-s3-bb.R")}
+```
+Verhalten für ungeeignete Inputs:
+```{r, bb_fail, , code = readLines("s3-bb-fail.R"), error = TRUE}
+```

--- a/feedback/s3-bb-sol.Rmd
+++ b/feedback/s3-bb-sol.Rmd
@@ -1,0 +1,44 @@
+<!--
+Knitten Sie dieses File in RStudio zur besseren Lesbarkeit, bitte...
+-->
+
+
+```{r, child = "s3-bb-ex.Rmd"}
+```
+
+----------------------------------------------------
+
+### Lösung:
+
+```{r, bb_sol, echo =TRUE, code = readLines("s3-bb-def.R")}
+```
+
+Bisschen umständlicher wäre:
+```{r, redef_bb_default}
+bb.default <- function(x) {
+  if (!is.character(x)) {
+    stop("non-character objects cannot be turned into bb-objects!\n")
+  }
+  result <- vapply(
+    X = x, FUN = new_bb, FUN.VALUE = character(1),
+    USE.NAMES = FALSE
+  )
+  class(result) <- c("bb", class(x))
+  result
+}
+bb.array <- function(x) {
+  # use bbfy.default, then restore dim attribute:
+  result <- bb(as.vector(x))
+  dim(result) <- dim(x)
+  class(result) <- c("bb", class(x))
+  result
+}
+bb.matrix <- function(x) {
+  # call array method explicitly:
+  bb.array(x)
+}
+```
+Dann würde die default-Methode nur für Vektoren aufgerufen. Obiger Code zeigt auch wie man sich manchmal durch den direkten Aufruf einer expliziten Methode behelfen kann um den *method dispatch*-Mechanismus zu umgehen (vgl. `bb.matrix()`, `bb.array()`).
+
+
+

--- a/feedback/s3-hadley-ex.Rmd
+++ b/feedback/s3-hadley-ex.Rmd
@@ -1,0 +1,35 @@
+## Lektüre & Quiz: `S3` 
+
+Lesen Sie das [`S3`](https://adv-r.hadley.nz/s3.html) Kapitel von H. Wickham's *Advanced R*. 
+Bearbeiten Sie (mindestens) die folgenden von dort übernommenen/inspirierten Aufgaben:
+
+- Was tut die `as.data.frame.data.frame()` Methode? Warum ist das verwirrend? Wie können Sie derartige Verwirrung in Ihrem eigenen Code vermeiden?
+- Beschreiben/erklären Sie das Verhalten dieses Codes:
+```r
+set.seed(1014)
+some_days <- as.Date("2019-11-24") + sample(10, 5)
+mean(some_days)
+# [1] "2019-11-30"
+mean(unclass(some_days))
+# [1] 18230.4
+```
+- Welche Klasse hat `x` im folgenden Code? Auf welchem *base type* basiert diese Klasse? Welche Attribute nutzt sie und wie sind die mathematischen Eigenschaften von Verteilungsfunktionen hier konkret implementiert? 
+```r
+x <- ecdf(rpois(100, 10))
+x
+# Empirical CDF 
+# Call: ecdf(rpois(100, 10))
+#  x[1:15] =      1,      4,      5,  ...,     16,     17
+```
+- Schreiben Sie einen neuen low-level Konstruktor für `data.frame`-Objekte (ohne die Funktionen `as.data.frame()` oder `data.frame()` zu benutzen, selbstverständlich). Machen Sie sich zunächst klar: Auf welchem *base type* basiert `data.frame`? Welche Attribute nutzt `data.frame`? Welche Restriktionen gelten für die verschiedenen Einträge und Attribute?  
+    *Hinweis*: Sehen Sie sich dafür zunächst mal so etwas wie `str(unclass(<irgend ein data.frame>))` an.
+- Kategorisieren Sie die Klassen der Rückgabe-Objekte von `lm(), factor(), table(), as.Date(), as.POSIXct(), ecdf(), ordered(), I()` in die Klassentypen *vector class*, *record style class*, *scalar class* die in *Advanced R* beschrieben  werden.
+- Wie sähe ein Konstruktor `new_lm` für Objekte der Klasse `lm` aus? Warum wäre ein solcher Konstruktor vermutlich nicht besonders nützlich? 
+
+<!--
+- Lesen Sie den Quellcode für `t()` und `t.test()`. Ist `t.test()` eine generische S3 Funktion oder eine S3 Methode? Was passiert **im Detail** wenn sie `t()` auf ein S3-Objekt mit Klasse `test` anwenden (s.u.)? Warum?
+```r
+x <- structure(1:10, class = "test")
+t(x)
+```
+-->

--- a/feedback/s3-hadley-sol.Rmd
+++ b/feedback/s3-hadley-sol.Rmd
@@ -1,0 +1,193 @@
+<!--
+Knitten Sie dieses File in RStudio zur besseren Lesbarkeit, bitte...
+-->
+
+
+```{r, child = "s3-hadley-ex.Rmd"}
+```
+
+----------------------------------------------------
+
+### Lösung:
+
+**`as.data.frame.data.frame`**:
+
+`as.data.frame.data.frame` *source code* mit Kommentaren:
+```{r 5_hadleys3_datadataframeframe}
+as.data.frame.data.frame <- function(x, row.names = NULL, ...) {
+  cl <- oldClass(x)
+  # entfernt alle Klassen die *vor* data.frame im class-vektor stehen
+  # also: falls das übergebene x in Unterklasse(n) von data.frame war,
+  # ist das zurückgegebene x nicht mehr in dieser/n:
+  i <- match("data.frame", cl)
+  if (i > 1L) {
+    class(x) <- cl[-(1L:(i - 1L))]
+  }
+  # checkt die übergebenenen row.names:
+  if (!is.null(row.names)) {
+    nr <- .row_names_info(x, 2L)
+    if (length(row.names) == nr) {
+      attr(x, "row.names") <- row.names
+    } else {
+      stop(sprintf(
+        ngettext(
+          nr, "invalid 'row.names', length %d for a data frame with %d row",
+          "invalid 'row.names', length %d for a data frame with %d rows"
+        ),
+        length(row.names), nr
+      ), domain = NA)
+    }
+  }
+  x
+}
+```
+Der Funktionsname ist verwirrend weil unfassbar vieldeutig, potentiell. Das könnte sein:
+
+- die `as`-Methode für die S3-Klasse `data.frame.data.frame`  
+  (es gibt weder eine S3 generic `as` noch die Klasse)
+- die `as.data`-Methode für die S3-Klasse `frame.data.frame`  
+  (es gibt weder eine S3 generic `as.data` noch die Klasse)
+- die `as.data.frame`-Methode für die S3-Klasse `data.frame` (... Bingo)
+- die `as.data.frame.data`-Methode für die S3-Klasse `frame`  
+  (es gibt weder eine S3 generic `as.data.frame.data` noch die Klasse)
+
+... und genau deshalb benutzen wir nie "." als Trenner zwischen Namensbestandteilen.
+
+---------------------
+
+What do you **`mean`**?
+
+```{r 5_hadleys3_somedays}
+set.seed(1014)
+some_days <- as.Date("2017-01-31") + sample(10, 5)
+
+mean(some_days)
+mean(unclass(some_days))
+
+some_days
+unclass(some_days)
+
+methods("mean")
+```
+Der Unterschied zwischen den beiden Aufrufen von mean ist dass beim ersten Aufruf von `mean` die `mean.Date` Methode aufgerufen wird, 
+während beim zweiten die `mean.default`-Methode aufgerufen wird. Da die interne Repräsentation
+der `Date` Klasse "number of days since 1970-01-01" (s. `?Date`) ist ergibt sich dann eben als Mittelwert beim zweiten Aufruf der obige Wert.
+
+---------------------
+
+```{r 5_hadleys3_ecdf}
+set.seed(1212)
+x <- rpois(100, 3)
+ecdf_x <- ecdf(x)
+str(ecdf_x)
+# Also: ecdf_x ist eine empirische Verteilungsfunktion ist eine Treppenfunktion ist eine Funktion ...
+body(ecdf_x)
+ls.str(environment(ecdf_x))
+# .. die ".approxfun" zur Interpolation der empirischen Quantile,
+# welche in der `enclosure` von ecdf_x als x und y abgelegt sind, benutzt:
+cumsum(table(x) / 100)
+```
+
+---------------------
+
+Konstruktor für **`data.frame`**
+
+Beispiel `data.frame`:
+```{r 5_hadleys3_data_frame1}
+str(iris)
+attributes(iris)
+str(unclass(iris))
+```
+Also : `data.frames` sind benamte listen mit zusätzlichem rownames-Attribut.
+
+Konstruktorfunktionen sind low-level Funktionen die *nur* das Objekt selbst anlegen --
+wie Hadley sagt:
+
+> The constructor should follow three principles: Be called `new_myclass()`, have one argument for the base object and one for each attribute, and check the type of the base object and the types of each attribute.
+
+Komplizierte input checks und so weiter gehören dann eigentlich eine *validator*-Funktion - also:
+
+```{r 5_hadleys3_data_frame2}
+new_data.frame <- function(x = list(), row.names = character()) {
+  stopifnot(is.list(x))
+  # NB: base-R also allows integers as row.names
+  stopifnot(is.character(row.names))
+  structure(x, 
+            row.names = row.names,
+            class = "data.frame")
+}
+```
+und dann brauchen wir (hier nicht gefragt) auch noch:
+```{r 5_hadleys3_data_frame3}
+# for arrays and matrices, "column length" is their first dimension,
+# for lists and atomic vectors, it's their length:
+get_nrows <- function(column) {
+  ifelse(inherits(column, c("array", "matrix")),
+         dim(column)[1], 
+         length(column))
+}
+
+validate_data.frame <- function(x) {
+  data <- unclass(x)
+  rownames <- attr(x, "row.names")
+  # dataframe columns must have syntactically valid names
+  # and can be atomic vectors, factors, arrays/matrices or lists
+  checkmate::assert_list(data, 
+                         names = "strict",
+                         types = c("atomic", "factor", "matrix", "array", "list")) 
+  if (!length(data) == 0) { # edge case: empty data.frame without columns
+    nrows <- vapply(data, get_nrows, numeric(1)) # see def. above
+    if (!all(nrows == nrows[1])) 
+       stop("all columns of `x` must have identical number of rows.",
+            call. = FALSE)
+    # row names must not be empty, must be unique (not enforced in base-R!)
+    checkmate::assert_character(rownames, min.chars = 1, len = nrows[1], 
+                                unique = TRUE)
+  } else {
+    # for empty data.frames, row.names can have any length:
+    checkmate::assert_character(rownames, min.chars = 1, unique = TRUE)
+  }
+  x
+}
+
+all.equal(
+  validate_data.frame(
+    new_data.frame(unclass(iris), rownames(iris))),
+  iris)
+
+str(validate_data.frame(
+  new_data.frame(list(int = 1:2, mat = matrix(1:4, 2, 2), fac = gl(2,1)), 
+                 as.character(1:2))))
+# etc....
+```
+
+----------------
+
+**class types**:
+
+- *vector*-Typ: existierender Vektor-`basetype` mit zusätzlichen Attributen, üblicherweise mehrere Werte, hier also:  
+  `factor` und `ordered`, die einfach nur `integer`-Vekoren mit zusätzlichem `levels`-Attribut sind, aber auch `as.POSIXct()` (s. `?DateTimeClasses`: "Class "POSIXct" represents the (signed) number of seconds since the beginning of 1970 (in the UTC time zone) as a numeric vector.") und `as.Date` (`?Date`: "Dates are represented as the number of days since 1970-01-01").
+- *record*-Typ: `as.POSIXlt`, s.Buch.
+- *scalar*-Typ: meistens benamte Listen, hier also: `lm`. Außerdem `table`, was als  `array` von mode `integer` abgespeichert wird. Auch `ecdf` (Unterklasse von `function`, s.o.) und `I`, welches einfach nur `AsIs` als erste Klasse an den `class`-Vektor dranhängt und sonst nichts am Objekt verändert. 
+
+---------------
+
+**`lm`**-Konstruktor:
+
+`lm`-Objekte sind benamte Listen mit etwa einem Dutzend Einträgen, haben also eine ziemlich komplexe Struktur. Die Werte der einzelnen Listeneinträge beruhen dabei haupsächlich auf den Berechnungen die man für das lineare Modell durchführen muss bzw repräsentieren die an `lm` übergebenen Argumente. Ein Konstruktor würde also diese Listeneinträge aneinanderhängen und die `mode`s aller Einträge überprüfen, während der *helper* die eigentlichen Berechnungen etc. durchführt. Insofern ist der Mehrwert einer Konstruktorfunktion hier relativ gering.
+
+<!--
+-----------
+
+```{r 5_hadleys3_ttest}
+isS3stdGeneric(t.test)
+t.test
+a <- structure(rnorm(10), class = "test")
+t(a)
+t
+t(unclass(a))
+```
+
+Übereifriger *method dispatch*: Weil `t()` eine S3 `generic` ist, triggert `t(a)` einen method dispatch.
+Da `class(a)` `"test"` ist, wird also eine Methode (Funktion) namens `t.test` gesucht. Diese wird gefunden und mit Argument `a` aufgerufen. `t.test()` ist aber selbst eine *generic*, keine Methode, triggert also nochmal einen *method dispatch*, gesucht wird jetzt aber die Funktion `t.test.test()` (!!). Die gibt es nüscht, also wird `t.test.default` benutzt, was in dem Fall hier mit einem t-Test prüft ob der Mittelwert von `a` O ist...
+-->

--- a/feedback/test-s3-bb.R
+++ b/feedback/test-s3-bb.R
@@ -1,0 +1,61 @@
+## test data for bb():
+texttest <- "Bedeutet nach jedem Vokal oder Diphtong die Konsonanten..."
+test_vec <- strsplit(texttest, " ")[[1]]
+test_matrix <- matrix(test_vec, nrow = 2, ncol = 4, byrow = TRUE)
+test_array <- array(test_vec, dim = c(2, 2, 2))
+test_list <- as.list(test_vec)
+test_listoflists <- list(as.list(test_vec), list(test_vec))
+test_factor <- factor(test_vec)
+test_ordered <- ordered(test_vec)
+
+str(bb(test_vec))
+str(bb(test_matrix))
+str(bb(test_list))
+str(bb(test_listoflists))
+str(bb(test_factor))
+str(bb(test_ordered))
+
+#-------------------------------------------------------------------------------
+# tests:
+library(testthat)
+
+expect_bb <- function(x, value) {
+  expect_is(x, "bb")
+  expect_equivalent(unlist(unclass(x)), value)
+}
+bb_texttest <-
+  "Bebedeubeutebet nabach jebedebem Vobokabal obodeber Dibiphtobong diebie Kobonsobonabanteben..."
+bb_testvec <- strsplit(bb_texttest, " ")[[1]]
+
+expect_bb(bb(texttest),
+          bb_texttest)
+
+expect_bb(bb(test_vec),
+          bb_testvec)
+
+expect_bb(bb(test_matrix),
+          matrix(bb_testvec,
+                 nrow = 2, ncol = 4, byrow = TRUE))
+expect_bb(bb(test_array),
+          array(bb_testvec,
+                dim = c(2, 2, 2)))
+
+expect_bb(bb(test_list),
+          bb_testvec)
+sapply(bb(test_list), expect_is, class = "bb") -> null
+
+expect_bb(bb(test_listoflists),
+          c(bb_testvec, bb_testvec))
+rapply(bb(test_listoflists), expect_is, class = "bb", classes = "ANY") -> null
+expect_length(bb(test_listoflists), 2)
+
+
+expect_equivalent(levels(bb(test_factor)),
+                  sort(bb_testvec)[c(1, 3, 2, 4:8)]) #alphabetic order changes!
+expect_is(bb(test_factor), "bb")
+expect_is(bb(test_factor), "factor")
+
+expect_equivalent(levels(bb(test_ordered)),
+                  sort(bb_testvec)[c(1, 3, 2, 4:8)]) #alphabetic order changes!
+expect_is(bb(test_ordered), "bb")
+expect_is(bb(test_ordered), "ordered")


### PR DESCRIPTION
@jaeeun-n 

Die Fragen zum Buch haben Sie super beantwortet, sehr gut!

**`bb`**:
- https://github.com/fort-w2021/s3-ex-jaeeun-n/blob/c1bed197d019190cd463fe0e703a1afc43b85264/s3-bb-sol.R#L2
should have moved the actual code (`gsub(pattern = match, replacement = "\\1\\2b\\2\\3", x = text)`) that does the work into the constructor, see my solution.  

 - https://github.com/fort-w2021/s3-ex-jaeeun-n/blob/c1bed197d019190cd463fe0e703a1afc43b85264/s3-bb-sol.R#L28
 this should have been `rapply` so that this can work for lists of lists and lists of lists of lists etc as well....
 
 - https://github.com/fort-w2021/s3-ex-jaeeun-n/blob/c1bed197d019190cd463fe0e703a1afc43b85264/s3-bb-sol.R#L37-L40
 don't like this at all -- you should not need any conditional logic depending on the class of the input INSIDE an S3 method. one of the major  reasons we use S3 methods is to avoid that kind of "manual" class dispatch. see my solution. 

- in addition, you now create ordered vectors that are only "ordered", but they *should* always have class c("ordered", "factor")... :( this is a general problem with the way you've structured this, e.g.
```
> bb(matrix("aba", 3 ,4))
     [,1]      [,2]      [,3]      [,4]     
[1,] "abababa" "abababa" "abababa" "abababa"
[2,] "abababa" "abababa" "abababa" "abababa"
[3,] "abababa" "abababa" "abababa" "abababa"
attr(,"class")
[1] "bb"
```
... but this should have class c("bb", "matrix"), not just "bb"!